### PR TITLE
Refactor VM to use 'any' type for stack and variable storage

### DIFF
--- a/compiler/bytecode.go
+++ b/compiler/bytecode.go
@@ -2,14 +2,13 @@ package compiler
 
 import (
 	"github.com/maniartech/uexl_go/code"
-	"github.com/maniartech/uexl_go/parser"
 )
 
 type ByteCode struct {
 	Instructions code.Instructions
-	Constants    []parser.Node
-	ContextVars  []parser.Node
-	SystemVars   []parser.Node
+	Constants    []any
+	ContextVars  []any
+	SystemVars   []any
 }
 
 func (c *Compiler) ByteCode() *ByteCode {

--- a/compiler/compiler_utils.go
+++ b/compiler/compiler_utils.go
@@ -39,25 +39,25 @@ func New() *Compiler {
 		previousInstruction: EmmittedInstruction{},
 	}
 	return &Compiler{
-		constants:   []parser.Node{},
+		constants:   []any{},
 		scopes:      []CompilationScope{mainScope},
 		scopeIndex:  0,
-		contextVars: []parser.Node{},
+		contextVars: []any{},
 	}
 }
 
-func NewWithState(constants []parser.Node) *Compiler {
+func NewWithState(constants []any) *Compiler {
 	compiler := New()
 	compiler.constants = constants
 	return compiler
 }
 
-func (c *Compiler) addConstant(node parser.Node) int {
+func (c *Compiler) addConstant(node any) int {
 	c.constants = append(c.constants, node)
 	return len(c.constants) - 1
 }
 
-func (c *Compiler) addContextVar(node parser.Node) int {
+func (c *Compiler) addContextVar(node any) int {
 	ident, ok := node.(*parser.Identifier)
 	if !ok {
 		panic("addContextVar: node is not *parser.Identifier")
@@ -104,7 +104,7 @@ func (c *Compiler) compilePredicateBlock(expr parser.Node) (int, error) {
 }
 
 func (c *Compiler) addPipeLocalVar(name string) int {
-	c.SystemVars = append(c.SystemVars, &parser.Identifier{Name: name})
+	c.SystemVars = append(c.SystemVars, name)
 	return len(c.SystemVars) - 1
 }
 

--- a/compiler/tests/help_test.go
+++ b/compiler/tests/help_test.go
@@ -44,7 +44,7 @@ func testInstructions(expected []code.Instructions, actual code.Instructions) er
 func testConstants(
 	t *testing.T,
 	expected []any,
-	actual []parser.Node,
+	actual []any,
 ) error {
 	if len(expected) != len(actual) {
 		return fmt.Errorf("wrong number of constants. got=%d, want=%d",
@@ -68,7 +68,7 @@ func testConstants(
 	return nil
 }
 
-func testNumerLiteral(expected float64, actual parser.Node) error {
+func testNumerLiteral(expected float64, actual any) error {
 	if num, ok := actual.(*parser.NumberLiteral); ok {
 		if num.Value != expected {
 			return fmt.Errorf("wrong number literal. got=%v, want=%v",
@@ -79,7 +79,7 @@ func testNumerLiteral(expected float64, actual parser.Node) error {
 	return fmt.Errorf("expected a number literal, got %T", actual)
 }
 
-func testStringLiteral(expected string, actual parser.Node) error {
+func testStringLiteral(expected string, actual any) error {
 	if str, ok := actual.(*parser.StringLiteral); ok {
 		if str.Value != expected {
 			return fmt.Errorf("wrong string literal. got=%q, want=%q",

--- a/vm/builtins.go
+++ b/vm/builtins.go
@@ -16,60 +16,57 @@ var Builtins = VMFunctions{
 }
 
 // len("abc") or len([1,2,3])
-func builtinLen(args ...parser.Node) (parser.Node, error) {
+func builtinLen(args ...any) (any, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("len expects 1 argument")
 	}
 	switch v := args[0].(type) {
-	case *parser.StringLiteral:
-		return &parser.NumberLiteral{Value: float64(len(v.Value))}, nil
-	case *parser.ArrayLiteral:
-		return &parser.NumberLiteral{Value: float64(len(v.Elements))}, nil
+	case string:
+		return float64(len(v)), nil
+	case []any:
+		return float64(len(v)), nil
 	default:
 		return nil, fmt.Errorf("len: unsupported type %T", args[0])
 	}
 }
 
 // substr("hello", 1, 3) => "ell"
-func builtinSubstr(args ...parser.Node) (parser.Node, error) {
+func builtinSubstr(args ...any) (any, error) {
 	if len(args) != 3 {
 		return nil, fmt.Errorf("substr expects 3 arguments")
 	}
-	str, ok := args[0].(*parser.StringLiteral)
+	str, ok := args[0].(string)
 	if !ok {
 		return nil, fmt.Errorf("substr: first argument must be a string")
 	}
-	start, ok1 := args[1].(*parser.NumberLiteral)
-	length, ok2 := args[2].(*parser.NumberLiteral)
+	start, ok1 := args[1].(float64)
+	length, ok2 := args[2].(float64)
 	if !ok1 || !ok2 {
 		return nil, fmt.Errorf("substr: start and length must be numbers")
 	}
-	s, l := int(start.Value), int(length.Value)
-	if s < 0 || l < 0 || s > len(str.Value) {
+	s, l := start, length
+	if s < 0 || l < 0 || s > float64(len(str)) {
 		return nil, fmt.Errorf("substr: invalid start or length")
 	}
-	end := s + l
-	if end > len(str.Value) {
-		end = len(str.Value)
-	}
-	return &parser.StringLiteral{Value: str.Value[s:end]}, nil
+	end := min(s+l, float64(len(str)))
+	return str[int(s):int(end)], nil
 }
 
 // contains("hello", "ll") => true
-func builtinContains(args ...parser.Node) (parser.Node, error) {
+func builtinContains(args ...any) (any, error) {
 	if len(args) != 2 {
 		return nil, fmt.Errorf("contains expects 2 arguments")
 	}
-	str, ok1 := args[0].(*parser.StringLiteral)
-	sub, ok2 := args[1].(*parser.StringLiteral)
+	str, ok1 := args[0].(string)
+	sub, ok2 := args[1].(string)
 	if !ok1 || !ok2 {
 		return nil, fmt.Errorf("contains: both arguments must be strings")
 	}
-	return &parser.BooleanLiteral{Value: strings.Contains(str.Value, sub.Value)}, nil
+	return strings.Contains(str, sub), nil
 }
 
 // set(obj, key, value) => obj with key set to value
-func builtinSet(args ...parser.Node) (parser.Node, error) {
+func builtinSet(args ...any) (any, error) {
 	if len(args) != 3 {
 		return nil, fmt.Errorf("set expects 3 arguments")
 	}


### PR DESCRIPTION
- Updated the VM implementation to replace specific parser.Node types with 'any' for greater flexibility.
- Modified methods to handle various data types (int, float64, string, bool) directly instead of relying on parser.Node.
- Adjusted the handling of binary and unary operations to accommodate the new type system.
- Enhanced the test suite to validate the changes and ensure compatibility with existing functionality.